### PR TITLE
remove howard's twitter link since it no longer exists

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2227,7 +2227,7 @@ Java Champions Directory can be found link:https://apex.oracle.com/champions[her
 |{counter:idx}
 |image:images/avatars/hlship.png[]
 |Howard Lewis Ship
-|link:https://twitter.com/hlship[@hlship]
+|
 |Portland, Oregon
 |USA
 |2010


### PR DESCRIPTION
this says the account is no longer there:  https://twitter.com/hlship