### PR TITLE
Add site.java generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ output/
 
 # VS Code project files
 .vscode/
+
+# Generated site content
+site/content/resources/mastodon.csv
+site/content/members.adoc
+site/content/stats.adoc


### PR DESCRIPTION
I was following the steps in [`CONTRIBUTING.adoc`](https://github.com/aalmiray/java-champions/blob/c5886e974561f5450a1615bd497f0c2e5b4e1693/CONTRIBUTING.adoc) to build the site. The `jbang` command (`site.java`) creates a few files that are not part of the repo so I think they should be in `.gitignore`.