### PR TITLE
Add Makefile to build the site and start the dev server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+clean:
+	rm site/content/resources/mastodon.csv site/content/members.adoc site/content/stats.adoc
+
+prerequisites-check:
+ifeq (, $(shell which jbang))
+	$(error 'No JBang in PATH, you may install it with https://sdkman.io')
+endif
+ifeq (, $(shell which jbake))
+	$(error 'No JBake in PATH, you may install it with https://sdkman.io')
+endif
+	@echo 'JBang and JBake installations found.'
+
+build: prerequisites-check
+	cd resources; jbang site.java ../java-champions.yml ../site/content/
+	cd site; jbake --bake
+
+server: build
+	cd site; jbake --server


### PR DESCRIPTION
While I was following the steps in [`CONTRIBUTING.adoc`](https://github.com/aalmiray/java-champions/blob/c5886e974561f5450a1615bd497f0c2e5b4e1693/CONTRIBUTING.adoc) to build the site, I was thinking if the steps could be automated so that local development could be simpler. I only tried this on MacOS but I think it should work on any POSIX-compatible OS; I'm not sure about Windows.