### PR TITLE
Update README.adoc for correct link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 
 image:site/assets/img/duke_champion.png[align="center"]
 
-The data collected in this repository is used to update link:javachampions.org[javachampions.org].
+The data collected in this repository is used to update link:https://javachampions.org[javachampions.org].
 
 == What is a Java Champion?
 


### PR DESCRIPTION
as title.
before this fix, the link is wrong.
![image](https://github.com/user-attachments/assets/90ea28d2-00ba-4622-99db-813f50664bfc)
