### PR TITLE
Add id fragment anchor to each entry of the members page

### DIFF
--- a/resources/site.java
+++ b/resources/site.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Function;
@@ -170,7 +171,10 @@ public class site {
         public List<String> status = new ArrayList<>();
 
         String formatted() {
-            var b = new StringBuilder("|{counter:idx}\n")
+            var b = new StringBuilder()
+                .append("|[[")
+                .append(nameAsAnchor())
+                .append("]]{counter:idx}\n")
                 .append("|image:")
                 .append(avatar)
                 .append("[]");
@@ -216,6 +220,16 @@ public class site {
 
         String asMastodonCsvEntry() {
             return social.getMastodonAccount() + ",true,false,";
+        }
+
+        String nameAsAnchor() {
+            // URL Encoding would have been _cleaner_ but that doesn't create output that works with flexmark
+            // instead this method will strip whitespace and punctuation, and lowercase the result so
+            // anchors are predictable and do not depend on how a name is capitalized
+            return name
+                    .replaceAll("\\s", "")
+                    .replaceAll("\\p{Punct}", "")
+                    .toLowerCase(Locale.ROOT);
         }
     }
 

--- a/site/assets/css/asciidoctor.css
+++ b/site/assets/css/asciidoctor.css
@@ -1,4 +1,6 @@
 @import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
+/* Fix anchor offset (50px is collapsed navbar height + 10px buffer) */
+html { scroll-padding-top: 60px; }
 /* ========================================================================== Embedded content ========================================================================== */
 /** Remove border when inside `a` element in IE 8/9. */
 img { border: 0; }


### PR DESCRIPTION
Example: `members.html#briandemers` will navigate to my profile

- Adds an `id` anchor to each member row, derived from the member name: whitespace and punctuation stripped, then lowercased so anchors are predictable regardless of how a name is capitalized
- Adds a CSS scroll offset so an anchored row lands below the nav bar instead of being hidden behind it
