### PR TITLE
Fix build and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,9 @@ output/
 .vscode/
 /out/
 
-# Generated site content
+# Generated/duplicate site content
 site/content/resources/mastodon.csv
 site/content/members.adoc
 site/content/stats.adoc
+site/content/podcasts.adoc
+site/content/resources/java-champions.yml

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 clean:
-	rm site/content/resources/mastodon.csv site/content/members.adoc site/content/stats.adoc
+	rm -f site/content/resources/mastodon.csv site/content/members.adoc site/content/stats.adoc site/content/podcasts.adoc site/content/resources/java-champions.yml
 
 prerequisites-check:
 ifeq (, $(shell which jbang))
@@ -11,7 +11,8 @@ endif
 	@echo 'JBang and JBake installations found.'
 
 build: prerequisites-check
-	cd resources; jbang site.java ../java-champions.yml ../site/content/
+	cd resources; jbang site.java ../ ../site/content/
+	cp java-champions.yml site/content/resources
 	cd site; jbake --bake
 
 server: build


### PR DESCRIPTION
Earlier changes (7f8efaa and 750fb33) broke the contract of `site.java`. The GitHub workflow was updated but the `.gitignore` and the `Makefile` were not. This resulted in not being able to build the project using `make` and if the project was built manually, generated files were not ignored.
